### PR TITLE
fix: added inv_depth_image publisher declaration

### DIFF
--- a/depth_anything_v2_ros2/depth_anything_v2_ros2.py
+++ b/depth_anything_v2_ros2/depth_anything_v2_ros2.py
@@ -109,6 +109,8 @@ class DepthAnythingROS(Node):
             depth=1)
         self.depth_image_pub = self.create_publisher(
             Image, self.depth_image_topic, sensor_qos_profile)
+        self.inv_depth_image_pub = self.create_publisher(
+            Image, self.inv_depth_image_topic, sensor_qos_profile)
 
         # Create subscribers
         self.image_sub = self.create_subscription(
@@ -129,6 +131,12 @@ class DepthAnythingROS(Node):
             'depth_image_topic').get_parameter_value().string_value
         self.get_logger().info(
             f'The parameter depth_image_topic is set to: [{self.depth_image_topic}]')
+        
+        self.declare_parameter('inv_depth_image_topic', 'inverted_depth')
+        self.inv_depth_image_topic = self.get_parameter(
+            'inv_depth_image_topic').get_parameter_value().string_value
+        self.get_logger().info(
+            f'The parameter inv_depth_image_topic is set to: [{self.inv_depth_image_topic}]')
 
         self.declare_parameter('device', 'cuda:0')
         self.device = self.get_parameter(


### PR DESCRIPTION
I found the following issue in the code:

In the image callback, the first "if condition" checks whether a subscriber is present for the depth_image_pub or for inv_depth_image_pub. However, a publisher was not created named "self.inv_depth_image_pub" , causing the code to crash.

![Screenshot from 2024-06-30 19-58-10](https://github.com/grupo-avispa/depth_anything_v2_ros2/assets/56277338/532d88f4-e1d9-4c0c-98ee-acb360012149)

I have added the publisher declaration in constructor for inv_depth_image. The topic name will be the one which is present in the params file, for which I had added the parameter assignment in the "get_params" function as well. 

Point to note-> I realized that the inv_depth_image will not be published at all, but the code will at least not crash for now. The inverse depth image generation can be added later.
